### PR TITLE
fix: yuidoc circular referencing problem

### DIFF
--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,0 +1,13 @@
+{
+  "name": "p5.sound.js",
+  "description": "p5.sound.js extends p5.js with Web Audio functionality.",
+  "version": "0.3.0-rc.0",
+  "url": "https://github.com/processing/p5.sound.js",
+  "options": {
+    "paths": [
+      "src"
+    ],
+    "exclude": "dist,out,node_modules",
+    "outdir": "./out"
+  }
+}

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,6 +1,6 @@
 {
   "name": "p5.sound.js",
-  "description": "p5.sound.js extends p5.js with Web Audio functionality.",
+  "description": "p5.sound.js extends the musical and sonic capabilities of p5.js. It is designed to be a minimal abstraction of the Tone.js library with a feature set that is inspired by p5.js's approach to accessible and poetic creative coding. Key functionalities include audio input, sound file playback and manipulation, effects, synthesis and analysis.",
   "version": "0.3.0-rc.0",
   "url": "https://github.com/processing/p5.sound.js",
   "options": {


### PR DESCRIPTION
previously npx yuidoc . was scanning the whole repo along with the dist files and it was causing circular referencing problem, and the doc generation was failing.

## before
<img width="798" height="435" alt="553903232-99f0b0a4-4201-4fb9-a4e9-bbd5046e63f5" src="https://github.com/user-attachments/assets/68fa12ca-0fb4-43ec-81a3-ce62396987d1" />

## after
<img width="797" height="313" alt="553903759-29f33403-ad7b-40bc-9d81-cea2e535493e" src="https://github.com/user-attachments/assets/d26fb539-0596-470b-b3c0-0c69341af6d5" />

@davepagurek, @ksen0 please take a look, whenever you have time.

Thanks a lot.

fixes #74 