### PR TITLE
Allow Tone.js to use its own prepared audio context (fix firefox cancelAndHold bug)

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -7,8 +7,6 @@
 import { getContext as ToneGetContext, setContext as ToneSetContext } from "tone/build/esm/core/Global.js";
 import { start as ToneStart } from "tone/build/esm/core/Global.js";
 
-let audioContext = null;
-
 function clamp(value, min, max) {
     return Math.min(Math.max(value, min), max);
 }
@@ -19,11 +17,10 @@ function clamp(value, min, max) {
  *  @return {AudioContext} the audio context
  */
 function getAudioContext() {
-    if (!audioContext) {
-        audioContext = new window.AudioContext();
-        ToneSetContext(audioContext);
-    }
-    return audioContext;
+    // Return the AudioContext that Tone.js owns rather than creating our own.
+    // Tone wraps its context with standardized-audio-context, which polyfills
+    // the Web Audio gaps Firefox and Safari have.
+    return ToneGetContext().rawContext;
 }
 
 /**
@@ -32,7 +29,7 @@ function getAudioContext() {
  *  @param {AudioContext} the desired AudioContext.
  */
 function setAudioContext(context) {
-    audioContext = context;
+    // Hand the supplied context to Tone; getAudioContext() then reflects it.
     ToneSetContext(context);
 }
 
@@ -49,8 +46,7 @@ function userStartAudio() {
  *  @function userStopAudio
  */
 function userStopAudio() {
-    const context = audioContext || ToneGetContext();
-    context.suspend();
+    getAudioContext().suspend();
 }
 
 export { clamp, getAudioContext, setAudioContext, userStartAudio, userStopAudio };


### PR DESCRIPTION
This is a suggested, illustrative fix for the `cancelAndHoldAtTime is not a function` bug that we saw causing various of the examples to fail on firefox.  

[Minimal repeatable example of the bug is here](https://editor.p5js.org/neill0/sketches/HrK5SeTTI) - (fails in firefox, doesn't complain in chrome), and another slightly longer, more typical [example, here](https://editor.p5js.org/neill0/sketches/vLQcI79VV).

A full root-cause-analysis is [here](https://gist.github.com/nbogie/f307c9ced7e81a39487a35ff3b7f7e22).

It is only a draft pull request because I haven't done exhaustive testing of it on all browsers or of anything more than the 22 examples in `examples/`.  The p5-to-tone example may show a regression (see section on testing).

### What it changes:
Rather than pass tone.js a new raw native audio context, let Tone.js use [its own prepared audio context](https://github.com/Tonejs/Tone.js/blob/main/README.md#audiocontext), and own the audio context throughout.

### Why:
Tone.js creates an AudioContext when it loads and shims it for maximum browser compatibility using [standardized-audio-context](https://github.com/chrisguttandin/standardized-audio-context).  This adds various missing functions missing from firefox and safari which Tone.js expects to be able to call unconditionally, one of which is [cancelAndHoldAtTime](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/cancelAndHoldAtTime#browser_compatibility).

p5.sound currently forces it to use a raw new native audio context instead of this prepared one, and in turn this causes various of our examples to fail in firefox (and likely safari, too) under certain conditions.
 
### Testing:
Tested with the browser based tests #85 plus #90 (which fixes a couple of errors in the examples).

All local examples then pass on firefox, and continue to pass on chrome,  with one exception `examples/p5-to-tone/`.  This looks like a newly introduced regression.

### AI disclosure: 

Claude Code was used in the investigation and preparation of this solution.  

Code review, testing, and this write-up by me, a human.