### PR TITLE
docs: fix misformatted @param in setAudioContext

### DIFF
--- a/src/core/Utils.js
+++ b/src/core/Utils.js
@@ -64,7 +64,7 @@ function getAudioContext() {
 /**
  *  Sets the AudioContext to a specified context to enable cross library compatibility.
  *  @function setAudioContext
- *  @param {AudioContext} the desired AudioContext.
+ *  @param {AudioContext} context the desired AudioContext to use.
  *  @example
  *  <div>
  *  <code>


### PR DESCRIPTION
## Summary
- The @param tag for setAudioContext() was missing the parameter name, so the doc generator parsed "the" as the param name instead of "context", rendering as setAudioContext(the).
- Fixed to `@param {AudioContext} context the desired AudioContext to use.`

Fixes #105

## Test plan
- [x] Built docs locally with yuidocjs and confirmed the parsed output now shows `name: "context", type: "AudioContext"`
- [x] Verified in browser: syntax renders as setAudioContext(context) with correct parameter description